### PR TITLE
fix: 配置生产环境认证回调URL为 /auth/callback

### DIFF
--- a/xinqing-app/GOOGLE_AUTH_SETUP.md
+++ b/xinqing-app/GOOGLE_AUTH_SETUP.md
@@ -35,7 +35,9 @@
 1. 添加授权重定向 URI: `https://qiqxttoczkaoanwfwbxn.supabase.co/auth/v1/callback`
 2. 添加授权 JavaScript 源: 
    - `http://localhost:3000` (开发环境)
-   - 你的生产域名 (生产环境)
+   - `https://xinqing-app.vercel.app` (生产环境)
+3. **⚠️ 生产环境特别注意**：还需添加应用回调URI
+   - `https://xinqing-app.vercel.app/auth/callback`
 
 ### 3. 创建数据库表
 
@@ -126,3 +128,38 @@ App.tsx
 1. 浏览器开发者工具的控制台日志
 2. Supabase Dashboard 的日志
 3. 网络请求是否成功
+
+## 🚀 生产环境部署配置
+
+### 重要：生产环境回调URL配置
+
+生产环境部署到 `https://xinqing-app.vercel.app` 需要特殊的回调URL配置：
+
+#### 1. Supabase Dashboard 配置
+**Authentication → URL Configuration**：
+- **Site URL**: `https://xinqing-app.vercel.app`
+- **Redirect URLs**: 添加 `https://xinqing-app.vercel.app/auth/callback`
+
+#### 2. Google Cloud Console 配置
+**已授权的重定向 URI** 中添加：
+- `https://xinqing-app.vercel.app/auth/callback`
+
+#### 3. 代码自动处理
+应用代码已自动处理环境差异：
+- **开发环境**: 重定向到 `http://localhost:3000/`
+- **生产环境**: 重定向到 `https://xinqing-app.vercel.app/auth/callback`
+
+#### 4. 认证流程
+1. 用户在生产环境点击登录
+2. 跳转到 Google OAuth 授权页面
+3. 用户授权后重定向到 `/auth/callback`
+4. 回调页面处理认证状态并跳转到主页
+
+#### 5. 验证部署
+部署完成后测试：
+1. 访问 `https://xinqing-app.vercel.app`
+2. 点击 "使用 Google 账号登录"
+3. 完成授权后应该正确跳转到应用主页
+4. 验证用户信息正确显示
+
+⚠️ **关键提醒**：生产环境必须使用 `/auth/callback` 作为回调路径，这与开发环境的 `/` 路径不同！

--- a/xinqing-app/src/App.tsx
+++ b/xinqing-app/src/App.tsx
@@ -10,6 +10,7 @@ import TodayMoodRecord from './pages/TodayMoodRecord';
 import HistoryPage from './pages/HistoryPage';
 import AnalyticsPage from './pages/AnalyticsPage';
 import PeriodPage from './pages/PeriodPage';
+import AuthCallback from './pages/AuthCallback';
 import CenterIcon from './components/CenterIcon';
 import UserProfile from './components/UserProfile';
 import SimpleLoading from './components/SimpleLoading';
@@ -420,6 +421,7 @@ const App: React.FC = () => {
 const AppWithAuth: React.FC = () => {
   const { user, loading } = useAuth();
   const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const location = useLocation();
 
   useEffect(() => {
     const initializeApp = async () => {
@@ -440,6 +442,16 @@ const AppWithAuth: React.FC = () => {
 
     initializeApp();
   }, [loading]);
+
+  // 认证回调页面，无需认证即可访问
+  if (location.pathname === '/auth/callback') {
+    return (
+      <>
+        <GlobalStyle />
+        <AuthCallback />
+      </>
+    );
+  }
 
   // 认证加载中
   if (loading || isInitialLoading) {

--- a/xinqing-app/src/contexts/AuthContext.tsx
+++ b/xinqing-app/src/contexts/AuthContext.tsx
@@ -76,10 +76,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signInWithGoogle = async () => {
     try {
       setLoading(true);
+      
+      // 根据环境设置不同的回调URL
+      const isDev = window.location.hostname === 'localhost';
+      const redirectTo = isDev 
+        ? `${window.location.origin}/` 
+        : 'https://xinqing-app.vercel.app/auth/callback';
+      
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/`,
+          redirectTo,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',

--- a/xinqing-app/src/pages/AuthCallback.tsx
+++ b/xinqing-app/src/pages/AuthCallback.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { theme } from '../styles/theme';
+import SimpleLoading from '../components/SimpleLoading';
+
+const CallbackContainer = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${theme.colors.gradient.primary};
+  padding: ${theme.spacing.lg};
+`;
+
+const AuthCallback: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleAuthCallback = () => {
+      console.log('🔄 处理认证回调...');
+      
+      // Supabase Auth 会自动处理回调并设置会话
+      // 我们只需要将用户重定向到主页
+      setTimeout(() => {
+        console.log('✅ 认证回调处理完成，重定向到主页');
+        navigate('/', { replace: true });
+      }, 2000);
+    };
+
+    handleAuthCallback();
+  }, [navigate]);
+
+  return (
+    <CallbackContainer>
+      <SimpleLoading
+        type="app"
+        size="large"
+        message="登录成功！正在跳转..."
+      />
+    </CallbackContainer>
+  );
+};
+
+export default AuthCallback;


### PR DESCRIPTION
$(cat <<'EOF'
## 🔧 问题描述
生产环境部署后需要正确的Google OAuth回调URL配置，当前配置导致认证回调失败。

## 💡 解决方案
配置生产环境使用专用的认证回调路径 `/auth/callback`，与开发环境的根路径区分。

## 🚀 主要变更

### 📱 环境自适应认证配置
- **开发环境**: 回调到 `http://localhost:3000/` 
- **生产环境**: 回调到 `https://xinqing-app.vercel.app/auth/callback`
- 自动根据 `window.location.hostname` 判断环境

### 🆕 认证回调页面组件
新增 `AuthCallback.tsx`:
- 处理生产环境的OAuth回调
- 显示友好的"登录成功"提示
- 自动跳转到应用主页
- 支持无认证状态访问（OAuth流程需要）

### 🔄 应用路由架构优化
更新 `App.tsx`:
- 在 `AppWithAuth` 组件层直接处理 `/auth/callback` 路由
- 确保回调页面在任何认证状态下都可访问
- 优化认证流程的用户体验

### 📚 完善部署文档
更新 `GOOGLE_AUTH_SETUP.md`:
- 详细的生产环境配置步骤
- Google Cloud Console 回调URI配置
- Supabase Dashboard URL配置
- 完整的部署验证流程

## 🛠 技术实现详情

### 环境检测和回调URL选择
```typescript
const isDev = window.location.hostname === 'localhost';
const redirectTo = isDev 
  ? `${window.location.origin}/` 
  : 'https://xinqing-app.vercel.app/auth/callback';
```

### 回调页面路由处理
```typescript
// 认证回调页面，无需认证即可访问
if (location.pathname === '/auth/callback') {
  return (
    <>
      <GlobalStyle />
      <AuthCallback />
    </>
  );
}
```

## ⚙️ 部署配置要求

### Google Cloud Console 配置
需要在 OAuth 2.0 客户端设置中添加：
- **已授权的重定向URI**: `https://xinqing-app.vercel.app/auth/callback`

### Supabase Dashboard 配置  
在 Authentication → URL Configuration 中设置：
- **Site URL**: `https://xinqing-app.vercel.app`
- **Redirect URLs**: 添加 `https://xinqing-app.vercel.app/auth/callback`

## 🧪 测试验证
- [x] 开发环境认证流程正常
- [x] 生产环境回调URL路径正确
- [x] 认证成功后正确跳转
- [x] 用户信息正确显示
- [x] 文档配置说明完整

## 📋 部署检查清单
- [ ] Google Cloud Console 添加生产回调URI
- [ ] Supabase 配置生产Site URL和Redirect URL  
- [ ] 代码合并到main分支
- [ ] Vercel自动部署完成
- [ ] 生产环境认证功能测试

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)