### PR TITLE
fix: 修复生产环境登录重定向到localhost的问题

### DIFF
--- a/xinqing-app/GOOGLE_AUTH_SETUP.md
+++ b/xinqing-app/GOOGLE_AUTH_SETUP.md
@@ -35,7 +35,9 @@
 1. 添加授权重定向 URI: `https://qiqxttoczkaoanwfwbxn.supabase.co/auth/v1/callback`
 2. 添加授权 JavaScript 源: 
    - `http://localhost:3000` (开发环境)
-   - 你的生产域名 (生产环境)
+   - `https://xinqing-app.vercel.app` (生产环境 - **必须配置！**)
+
+⚠️ **重要提醒**：如果生产环境登录后跳转到 `http://localhost:3000/#access_token`，说明 Google OAuth 配置中缺少生产域名。请确保在 Google Cloud Console 的 OAuth 2.0 客户端设置中添加 `https://xinqing-app.vercel.app` 作为授权 JavaScript 源。
 
 ### 3. 创建数据库表
 
@@ -126,3 +128,28 @@ App.tsx
 1. 浏览器开发者工具的控制台日志
 2. Supabase Dashboard 的日志
 3. 网络请求是否成功
+
+## 🚨 生产环境常见问题
+
+### 问题：登录后跳转到 `http://localhost:3000/#access_token`
+**症状**：在生产环境 `https://xinqing-app.vercel.app` 登录 Google 后，页面跳转到 `http://localhost:3000/#access_token` 而不是生产环境域名。
+
+**根本原因**：Google Cloud Console 的 OAuth 2.0 客户端配置中缺少生产环境域名。
+
+**解决方案**：
+1. 登录 [Google Cloud Console](https://console.cloud.google.com/)
+2. 进入 "APIs & Services" → "Credentials"
+3. 找到你的 OAuth 2.0 客户端 ID 并点击编辑
+4. 在 "Authorized JavaScript origins" 中添加：
+   - `https://xinqing-app.vercel.app`
+5. 点击 "Save" 保存配置
+6. 等待几分钟配置生效，然后重新测试登录
+
+**验证修复**：
+- 在生产环境登录后，URL 应该变为：`https://xinqing-app.vercel.app/#access_token=...`
+- 控制台应该显示正确的重定向URL：`🔄 认证重定向URL: https://xinqing-app.vercel.app/`
+
+### 其他检查项目
+- 确认 Supabase Dashboard 的 Site URL 设置为 `https://xinqing-app.vercel.app`
+- 确认 Redirect URLs 包含 `https://xinqing-app.vercel.app/`
+- 检查浏览器控制台是否有错误信息

--- a/xinqing-app/src/contexts/AuthContext.tsx
+++ b/xinqing-app/src/contexts/AuthContext.tsx
@@ -76,10 +76,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signInWithGoogle = async () => {
     try {
       setLoading(true);
+      
+      // 明确设置生产环境的重定向URL
+      const currentOrigin = window.location.origin;
+      const redirectTo = `${currentOrigin}/`;
+      
+      console.log('🔄 认证重定向URL:', redirectTo);
+      
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/`,
+          redirectTo,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',


### PR DESCRIPTION
$(cat <<'EOF'
## 🐛 问题描述
用户报告生产环境登录后错误跳转到 `http://localhost:3000/#access_token` 而不是正确的生产环境URL `https://xinqing-app.vercel.app/#access_token`。

## 🔍 根本原因分析
这个问题的根本原因是 **Google Cloud Console** 的 OAuth 2.0 客户端配置中缺少生产环境域名。当 Google OAuth 没有找到匹配的 Authorized JavaScript Origins 时，会回退到第一个配置的域名（通常是 `http://localhost:3000`）。

## 💡 解决方案

### 📝 代码改进
1. **增强调试能力**：添加重定向URL的控制台日志
2. **提高可读性**：明确定义 `currentOrigin` 变量
3. **便于排查**：在认证流程中输出实际使用的重定向URL

```typescript
// 明确设置生产环境的重定向URL
const currentOrigin = window.location.origin;
const redirectTo = `${currentOrigin}/`;

console.log('🔄 认证重定向URL:', redirectTo);
```

### 📚 文档完善
1. **明确配置要求**：具体指定需要添加 `https://xinqing-app.vercel.app`
2. **故障排除指南**：添加专门的生产环境问题排查章节
3. **详细操作步骤**：提供Google Cloud Console的具体配置步骤
4. **验证方法**：说明如何确认修复效果

## ⚙️ 必需的配置更改

### Google Cloud Console 配置
用户需要在 OAuth 2.0 客户端设置中添加：

**Authorized JavaScript origins**:
- `http://localhost:3000` (开发环境)
- `https://xinqing-app.vercel.app` (生产环境 - **必须添加！**)

### Supabase Dashboard 配置
确认以下设置正确：
- **Site URL**: `https://xinqing-app.vercel.app`
- **Redirect URLs**: `https://xinqing-app.vercel.app/`

## 🧪 验证修复效果

修复后的预期行为：
- ✅ 生产环境登录跳转到：`https://xinqing-app.vercel.app/#access_token=...`
- ✅ 浏览器控制台显示：`🔄 认证重定向URL: https://xinqing-app.vercel.app/`
- ✅ 用户成功登录并显示个人信息

## 🔧 技术细节

这个修复主要是：
1. **诊断工具**：添加日志帮助确认重定向URL设置
2. **文档指导**：提供详细的配置步骤避免配置错误
3. **故障排除**：包含常见问题的解决方案

代码本身的逻辑是正确的（`${window.location.origin}/`），问题出在外部OAuth配置上。

## 📋 用户操作清单
- [ ] 在Google Cloud Console添加生产域名
- [ ] 确认Supabase Site URL设置
- [ ] 测试生产环境登录流程
- [ ] 验证URL跳转正确性

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)