### PR TITLE
fix: 添加Google Search Console验证标签

### DIFF
--- a/xinqing-app/public/index.html
+++ b/xinqing-app/public/index.html
@@ -8,6 +8,9 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     
+    <!-- Google Search Console Verification -->
+    <meta name="google-site-verification" content="_lPusqT7mKcyLKrjmk2L23vvvkQ56f06YX3v6TyQVAI" />
+    
     <!-- Basic Meta Tags -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#E6E0F2" />


### PR DESCRIPTION
## 🔍 Google Search Console验证

添加Google Search Console网站所有权验证标签，以便完成网站在Google搜索工具中的注册和配置。

### 📝 变更内容
- 在 `public/index.html` 的 `<head>` 部分添加verification meta标签
- 验证码：`_lPusqT7mKcyLKrjmk2L23vvvkQ56f06YX3v6TyQVAI`
- 位置：head部分，在Basic Meta Tags之前

### 🎯 目的
- 完成Google Search Console网站验证
- 启用网站在Google搜索结果中的监控和优化
- 为后续SEO数据分析做准备

### 📍 验证标签位置
```html
<head>
  <!-- Google Search Console Verification -->
  <meta name="google-site-verification" content="_lPusqT7mKcyLKrjmk2L23vvvkQ56f06YX3v6TyQVAI" />
</head>
```

### ✅ 验证步骤
1. 部署后，Google Search Console将能够验证网站所有权
2. 验证成功后可以提交sitemap和监控搜索表现
3. 开始收集搜索分析数据

### 🚀 后续行动
- 验证Google Search Console网站所有权
- 提交 `https://xinqing-app.vercel.app/sitemap.xml`
- 开始监控搜索引擎收录和排名